### PR TITLE
training typo

### DIFF
--- a/templates/training.html
+++ b/templates/training.html
@@ -5,7 +5,7 @@
     <h2 class="title is-4">Training Courses</h2>
     Hi, I am the developer and maintainer of the Rust Digger application and web site.
     My name is <a href="https://szabgab.com/">Gábor Szabó</a> and I help people to develop software faster and with less bugs
-    by providing various traiing courses at corporations and other organizations.
+    by providing various training courses at corporations and other organizations.
     <p>
     If you feel that one of <a href="https://szabgab.com/">the courses</a> could improve the
     efficiency of your team or that it can teach tools and techniques that are needed in your organization then get in touch with


### PR DESCRIPTION
There is a single typo in the training.html 
Instead of training courses it is written traiing courses. 