### PR TITLE
Replace download.sh with rust binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +361,28 @@ name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
+name = "filetime"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1036,6 +1067,7 @@ dependencies = [
  "chrono",
  "clap",
  "csv",
+ "flate2",
  "liquid",
  "log",
  "once_cell",
@@ -1044,6 +1076,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_logger",
+ "tar",
 ]
 
 [[package]]
@@ -1219,6 +1252,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -1708,4 +1752,13 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "xattr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
+dependencies = [
+ "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 chrono = "0.4.26"
 clap = { version = "4.3", features = ["derive"] }
 csv = "1.2.2"
+flate2 = "1.0.28"
 liquid = "0.26.4"
 log = "0.4"
 once_cell = "1.18.0"
@@ -17,6 +18,7 @@ reqwest = { version = "0.11.20", features = ["blocking"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simple_logger = "4.2"
+tar = "0.4.40"
 
 [[bin]]
 name = "rust-digger-html"
@@ -34,3 +36,7 @@ path = "src/vcs.rs"
 [[bin]]
 name = "rust-digger-clone"
 path = "src/clone.rs"
+
+[[bin]]
+name = "rust-digger-download"
+path = "src/download.rs"

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ cd rust-digger
 
 Optionally install [pre-commit](https://pre-commit.com/) and then run `pre-commit install` to configure it on this project.
 
-Download the data from crates: (I think this is the only code that assumes some non-Rust tools) See issues [#1](https://github.com/szabgab/rust-digger/issues/1) and [#2](https://github.com/szabgab/rust-digger/issues/2)
+Download the data from static.crates.io
 
 ```
-./download.sh
+cargo run --bin rust-digger-download
 ```
 
 Clone 15 repositories of the crates that were release in the last 10 days:
@@ -74,7 +74,7 @@ Discussed here: https://crates.io/data-access
 As of 2023.06.17
 
 1. The git repository https://github.com/rust-lang/crates.io-index does not contain the meta data, such as the github URL
-1. The https://static.crates.io/db-dump.tar.gz is 305 Mb It unzipped to a folder called `2023-06-16-020046` which is 1.1 Gb and contains CSV dumps of a Postgresql database.
+1. The https://static.crates.io/db-dump.tar.gz is 305 Mb It unzipped to a timestamped folder called `YYYY-MM-DD-020046` which is 1.1 Gb and contains CSV dumps of a Postgresql database.
 
 The fetching and unzipping is done by `download.sh`.
 

--- a/all.sh
+++ b/all.sh
@@ -1,8 +1,8 @@
 set -e -u
 #-o pipefail
 cd /home/gabor/work/rust-digger
-./download.sh;
 /home/gabor/.cargo/bin/cargo build --release > /tmp/rust-digger-build.log 2> /tmp/rust-digger-build.err
+./target/release/rust-digger-download > /tmp/rust-digger-clone.log 2> /tmp/rust-digger-clone.err
 ./target/release/rust-digger-clone --recent 10 > /tmp/rust-digger-clone.log 2> /tmp/rust-digger-clone.err
 ./target/release/rust-digger-vcs > /tmp/rust-digger-vcs.log 2> /tmp/rust-digger-vcs.err
 ./target/release/rust-digger-html > /tmp/rust-digger-html.log 2> /tmp/rust-digger-html.err

--- a/download.sh
+++ b/download.sh
@@ -1,6 +1,1 @@
-rm -f db-dump.tar.gz
-rm -frd data/
-time wget --quiet https://static.crates.io/db-dump.tar.gz
-time tar xzf db-dump.tar.gz
-DIR=$(ls -d1 2023-* | head -n 1 | cut -d'/' -f1)
-mv "$DIR" "data"
+cargo run --bin rust-digger-download > /tmp/rust-digger-download.log 2> /tmp/rust-digger-download.err

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,0 +1,47 @@
+use flate2::read::GzDecoder;
+use std::{fs, io, path};
+use tar::Archive;
+
+fn year_of_yesterday() -> String {
+    let now = chrono::Local::now();
+    let yesterday = now - chrono::Duration::days(1);
+    yesterday.format("%Y").to_string()
+}
+
+fn main() {
+    let data_dir = "./data";
+    let db_archive = "./db-dump.tar.gz";
+
+    if fs::metadata(data_dir).is_ok() {
+        fs::remove_dir_all(data_dir).expect("should remove previously extracted data");
+    }
+    if fs::metadata(path::Path::new(db_archive)).is_ok() {
+        fs::remove_file(db_archive).expect("should remove previous database archive");
+    }
+
+    let mut response = reqwest::blocking::get("https://static.crates.io/db-dump.tar.gz")
+        .expect("should fetch new database archive from static.crates.io");
+
+    let mut file = fs::File::create(path::Path::new(db_archive))
+        .expect("should create new file to write database archive to");
+    let _ =
+        io::copy(&mut response, &mut file).expect("should copy fetched response into created file");
+
+    let tar_gz = fs::File::open(db_archive).expect("should open new database archive file");
+    let tar = GzDecoder::new(tar_gz);
+    let mut archive = Archive::new(tar);
+    archive
+        .unpack(".")
+        .expect("should unpack archive file into current directory");
+
+    let extracted_dir = fs::read_dir(path::Path::new("."))
+        .expect("should read directory extracted from archive")
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_str().unwrap().to_string())
+        .filter(|entry| entry.starts_with(&year_of_yesterday()))
+        .map(|entry| entry.split('/').next().unwrap().to_string())
+        .next()
+        .expect("should find name of directory extracted from archive");
+
+    fs::rename(extracted_dir, "data").expect("should rename extracted directory to 'data'");
+}


### PR DESCRIPTION
Closes #1 and #2 
Hey @szabgab, awesome project!
This PR replaces the functionality of `download.sh` with a rust binary so that the download step does not have to be platform specific.
Tested on:
- Windows 11 22H2
- MacOS Ventura 13.6.1
- Linux Mint 21.2

Currently there is no output but it can be added as part of this PR if desired. 